### PR TITLE
[BUGFIX] Add missing Services.yaml

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,9 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+
+    Sunzinet\SzQuickfinder\:
+        resource: '../Classes/*'
+


### PR DESCRIPTION
While trying to use dependency injection in combination with other extensions, TYPO3 complains about missing service for every class that should be injected. The following example code doesn't work without the Services.yaml.

```php
/**
 * @param \Sunzinet\SzQuickfinder\Domain\Repository\SearchRepository
 * @return void
 */
public function injectSearchRepository(\Sunzinet\SzQuickfinder\Domain\Repository\SearchRepository $searchRepository): void
{
    $this->searchRepository = $searchRepository;
}
```