### PR TITLE
[BUGFIX] Add extension-key property to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
   },
   "extra": {
       "typo3/cms": {
+          "extension-key": "sz_quickfinder",
           "cms-package-dir": "{$vendor-dir}/typo3/cms",
           "web-dir": ".Build/Web",
           "Package": {


### PR DESCRIPTION
Not providing this property will emit a deprecation notice and
will fail in future versions.

See https://docs.typo3.org/m/typo3/reference-coreapi/11.5/en-us/ExtensionArchitecture/ComposerJson/Index.html#extra